### PR TITLE
Added failing test for pack/unpack of $$

### DIFF
--- a/t/22_pid_pack_unpack.t
+++ b/t/22_pid_pack_unpack.t
@@ -1,0 +1,12 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+use Data::MessagePack;
+
+my $mp = Data::MessagePack->new();
+is( $mp->unpack($mp->pack($$)), $$, 'pack then unpack of $$ returns same number' );
+
+done_testing();


### PR DESCRIPTION
I've added a failing test case for serialization/deserialization of the special $$ (pid) variable in perl.

For some reason it gets clobbered when going through the most basic round-trip.

PS: This was run against the released CPAN version (0.41), not the current git master. The reason for this was that I couldn't install Module::Install::XSUtil on perl 5.16.0 built with ithreads (via perlbrew), it was just hanging when trying to execute t/01_example in its test suite. Trying to force install didn't help. I guess this should probably be reported in Module::Install::XSUtil bug tracker.
