### PR TITLE
support tied hashes (with test case)

### DIFF
--- a/t/24_tied.t
+++ b/t/24_tied.t
@@ -1,0 +1,44 @@
+use t::Util;
+use Test::More tests => 4;
+use Data::MessagePack;
+
+package MyTieHash;
+use Tie::Hash;
+our @ISA = ('Tie::StdHash');
+
+package main;
+
+my %data;
+tie( %data, 'Tie::StdHash' );
+%data = (
+	 'module'     => 'DiskUsage',
+	 'func'       => 'fetchdiskusagewithextras',
+	 'apiversion' => '2',
+	);
+
+{
+    my $mp = Data::MessagePack->new();
+    my $packed = eval { $mp->pack( \%data ); };
+    ok(unpack("C", substr($packed,0,1)) == 131, "pack did a map with 3 elems");
+    #diag unpack("CC", substr($packed,0,2)),$packed;
+    my $unpacked = eval { $mp->unpack( $packed ); };
+    if ($@) {
+      ok( 0, "unpack tied" );
+    } else {
+      ok( $unpacked, "round trip tied" );
+    }
+}
+
+{
+    local $ENV{PERL_DATA_MESSAGEPACK} = 'pp';
+    my $mp = Data::MessagePack->new();
+    my $packed = eval { $mp->pack( \%data ); };
+    ok(unpack("C", substr($packed,0,1)) == 131, "PP pack did a map with 3 elems");
+    #diag unpack("CC", substr($packed,0,2)),$packed;
+    my $unpacked = eval { $mp->unpack( $packed ); };
+    if ($@) {
+      ok( 0, "PP unpack tied" );
+    } else {
+      ok( $unpacked, "PP round trip tied" );
+    }
+}

--- a/xs-src/pack.c
+++ b/xs-src/pack.c
@@ -234,6 +234,12 @@ STATIC_INLINE void _msgpack_pack_rv(pTHX_ enc_t *enc, SV* sv, int depth) {
         int count = hv_iterinit(hval);
         HE* he;
 
+	if (SvTIED_mg(sv,PERL_MAGIC_tied)) {
+          count = 0;
+          while (hv_iternext (hval))
+            ++count;
+          hv_iterinit (hval);
+        }
         msgpack_pack_map(enc, count);
 
         if (enc->canonical) {


### PR DESCRIPTION
The problem is that the length of tied hashes are 0.
The trick was taken from http://cpansearch.perl.org/src/MLEHMANN/JSON-XS-2.32/XS.xs

Note, that I haven't added support for tied arrays
