### PR TITLE
Fix undefined behavior issue of overflow

### DIFF
--- a/xs-src/pack.c
+++ b/xs-src/pack.c
@@ -158,7 +158,7 @@ STATIC_INLINE int try_int(enc_t* enc, const char *p, size_t len) {
 
     if (negative) {
         if (num > 0x80000000) { return 0; }
-        msgpack_pack_int32(enc, ((int32_t)num) * -1);
+        msgpack_pack_int32(enc, ((int32_t)-num));
     } else {
         if (num > 0xFFFFFFFF) { return 0; }
         msgpack_pack_uint32(enc, (uint32_t)num);


### PR DESCRIPTION
If 'num' equals to INT_MIN, then ((int32_t)num * -1) causes overflow and
its behavior is undefined in C specification.

This is related to #23.

See @kazuho's information
- https://github.com/msgpack/msgpack-perl/issues/23#issuecomment-152361873
