### PR TITLE
Fix compile warning about unused variable

### DIFF
--- a/xs-src/unpack.c
+++ b/xs-src/unpack.c
@@ -302,8 +302,6 @@ XS(xs_unpack) {
     dXSARGS;
     SV* const self = ST(0);
     SV* const data = ST(1);
-    size_t limit;
-
     unpack_user u = UNPACK_USER_INIT;
 
     // setup configuration
@@ -317,13 +315,7 @@ XS(xs_unpack) {
         }
     }
 
-    if (items == 2) {
-        limit = sv_len(data);
-    }
-    else if(items == 3) {
-        limit = SvUVx(ST(2));
-    }
-    else {
+    if (!(items == 2 || items == 3)) {
         Perl_croak(aTHX_ "Usage: Data::MessagePack->unpack('data' [, $limit])");
     }
 


### PR DESCRIPTION
This change fixes a following compile warning.

```
xs-src/unpack.c: In function ‘xs_unpack’:
xs-src/unpack.c:305:12: warning: variable ‘limit’ set but not used [-Wunused-but-set-variable]
     size_t limit;
```