### PR TITLE
Add Types::Serialiser compatibility.

### DIFF
--- a/lib/Data/MessagePack.pm
+++ b/lib/Data/MessagePack.pm
@@ -36,7 +36,7 @@ sub new {
     return bless \%args, $class;
 }
 
-foreach my $name(qw(canonical prefer_integer utf8)) {
+foreach my $name(qw(canonical prefer_integer utf8 prefer_types_serialiser)) {
     my $setter = sub {
         my($self, $value) = @_;
         $self->{$name} = defined($value) ? $value : 1;
@@ -109,6 +109,25 @@ details.
 If you want to get more information about the MessagePack format,
 please visit to L<http://msgpack.org/>.
 
+=head1 ABOUT BOOLEANS
+
+Because Perl lacks a boolean type, this module follows the following
+conventions:
+
+=over
+
+=item * C<Types::Serialiser::true> and C<Data::MessagePack::Boolean::true>
+are serialized as boolean true. Likewise, C<Types::Serialiser::false> and
+C<Data::MessagePack::Boolean::false> are serialized as boolean false.
+
+=item * By default, this module’s C<unpack> method recreates boolean
+values as either C<Data::MessagePack::Boolean::true> or
+C<Data::MessagePack::Boolean::false>. If you enable the
+C<prefer_types_serialiser> flag, then C<unpack> will use
+C<Types::Serialiser::true> and C<Types::Serialiser::false> instead.
+
+=back
+
 =head1 METHODS
 
 =over
@@ -157,6 +176,15 @@ apply C<utf8::encode()> to all the string values.
 
 In other words, this property tell C<$mp> to deal with B<text strings>.
 See L<perlunifaq> for the meaning of B<text string>.
+
+=item C<< $mp = $mp->prefer_types_serialiser([ $enable ]) >>
+
+=item C<< $enabled = $mp->get_prefer_types_serialiser() >>
+
+If I<$enable> is true (or missing), then the C<unpack> method will use
+L<Types::Serialiser> (rather than C<Data::MessagePack::Boolean>) to represent
+boolean values. This is useful for interoperability with other Perl
+serialization modules like L<JSON>.
 
 =item C<< $packed = $mp->pack($data) >>
 

--- a/t/60_types_serialiser.t
+++ b/t/60_types_serialiser.t
@@ -1,0 +1,24 @@
+use Test::More;
+
+use strict;
+use warnings;
+
+use Data::MessagePack;
+
+if ( eval { require Types::Serialiser } ) {
+    plan tests => 1;
+
+    my $mp = Data::MessagePack->new();
+
+    $mp->prefer_types_serialiser(1);
+
+    my $src = [ Types::Serialiser::false(), Types::Serialiser::true() ];
+
+    my $enc = $mp->pack($src);
+    my $dec = $mp->unpack($enc);
+
+    is_deeply( $dec, $src, 'round-trip' ) or diag explain $dec;
+}
+else {
+    plan skip_all => $@;
+};

--- a/t/61_types_serialiser_pp.t
+++ b/t/61_types_serialiser_pp.t
@@ -1,0 +1,26 @@
+use Test::More;
+
+use strict;
+use warnings;
+
+BEGIN { $ENV{PERL_ONLY} = 1 }
+
+use Data::MessagePack;
+
+if ( eval { require Types::Serialiser } ) {
+    plan tests => 1;
+
+    my $mp = Data::MessagePack->new();
+
+    $mp->prefer_types_serialiser(1);
+
+    my $src = [ Types::Serialiser::false(), Types::Serialiser::true() ];
+
+    my $enc = $mp->pack($src);
+    my $dec = $mp->unpack($enc);
+
+    is_deeply( $dec, $src, 'round-trip' ) or diag explain $dec;
+}
+else {
+    plan skip_all => $@;
+};

--- a/xs-src/MessagePack.xs
+++ b/xs-src/MessagePack.xs
@@ -9,6 +9,8 @@ XS(xs_unpack);
 XS(xs_unpacker_new);
 XS(xs_unpacker_utf8);
 XS(xs_unpacker_get_utf8);
+XS(xs_unpacker_prefer_types_serialiser);
+XS(xs_unpacker_get_prefer_types_serialiser);
 XS(xs_unpacker_execute);
 XS(xs_unpacker_execute_limit);
 XS(xs_unpacker_is_finished);
@@ -38,6 +40,9 @@ BOOT:
     newXS("Data::MessagePack::Unpacker::data",          xs_unpacker_data, __FILE__);
     newXS("Data::MessagePack::Unpacker::reset",         xs_unpacker_reset, __FILE__);
     newXS("Data::MessagePack::Unpacker::DESTROY",       xs_unpacker_destroy, __FILE__);
+
+    newXS("Data::MessagePack::Unpacker::prefer_types_serialiser",          xs_unpacker_prefer_types_serialiser, __FILE__);
+    newXS("Data::MessagePack::Unpacker::get_prefer_types_serialiser",      xs_unpacker_get_prefer_types_serialiser, __FILE__);
 }
 
 #ifdef USE_ITHREADS

--- a/xs-src/pack.c
+++ b/xs-src/pack.c
@@ -231,8 +231,17 @@ STATIC_INLINE void _msgpack_pack_rv(pTHX_ enc_t *enc, SV* sv, int depth, bool ut
                 msgpack_pack_false(enc);
             }
         } else {
-            croak ("encountered object '%s', Data::MessagePack doesn't allow the object",
-                           SvPV_nolen(sv_2mortal(newRV_inc(sv))));
+            HV *stash = gv_stashpv ("Types::Serialiser::Boolean", 1); // TODO: cache?
+            if (stash && (SvSTASH (sv) == stash)) {
+                if (SvIV(sv)) {
+                    msgpack_pack_true(enc);
+                } else {
+                    msgpack_pack_false(enc);
+                }
+            } else {
+                croak ("encountered object '%s', Data::MessagePack doesn't allow the object",
+                            SvPV_nolen(sv_2mortal(newRV_inc(sv))));
+            }
         }
     } else if (svt == SVt_PVHV) {
         HV* hval = (HV*)sv;


### PR DESCRIPTION
Issue #17: Types::Serialiser is useful to support for interoperability
with other CPAN serialization modules like JSON. This patch provides
that capability in both XS and PP.