### PR TITLE
Switch to Types::Serialiser booleans

### DIFF
--- a/lib/Data/MessagePack.pm
+++ b/lib/Data/MessagePack.pm
@@ -5,17 +5,7 @@ use 5.008001;
 
 our $VERSION = '1.00';
 
-sub true () {
-    require Data::MessagePack::Boolean;
-    no warnings 'once';
-    return $Data::MessagePack::Boolean::true;
-}
-
-sub false () {
-    require Data::MessagePack::Boolean;
-    no warnings 'once';
-    return $Data::MessagePack::Boolean::false;
-}
+use Data::MessagePack::Boolean;
 
 if ( !__PACKAGE__->can('pack') ) { # this idea comes from Text::Xslate
     my $backend = $ENV{PERL_DATA_MESSAGEPACK} || ($ENV{PERL_ONLY} ? 'pp' : '');

--- a/lib/Data/MessagePack/Boolean.pm
+++ b/lib/Data/MessagePack/Boolean.pm
@@ -1,15 +1,17 @@
-package Data::MessagePack::Boolean;
-use strict;
-use warnings;
-use overload
-    'bool' => sub { ${ $_[0] } },
-    '0+'   => sub { ${ $_[0] } },
-    '""'   => sub { ${ $_[0] } ? 'true' : 'false' },
 
-    fallback => 1,
-;
+use Types::Serialiser ();
 
-our $true  = do { bless \(my $dummy = 1) };
-our $false = do { bless \(my $dummy = 0) };
+BEGIN {
+    *Data::MessagePack::Boolean:: = *Types::Serialiser::Boolean::;
+}
+
+package
+  Data::MessagePack;
+
+BEGIN {
+    *true    = \&Types::Serialiser::true;
+    *false   = \&Types::Serialiser::false;
+    *is_bool = \&Types::Serialiser::is_bool;
+}
 
 1;

--- a/lib/Data/MessagePack/PP.pm
+++ b/lib/Data/MessagePack/PP.pm
@@ -155,8 +155,9 @@ BEGIN {
     @Data::MessagePack::ISA           = qw(Data::MessagePack::PP);
     @Data::MessagePack::Unpacker::ISA = qw(Data::MessagePack::PP::Unpacker);
 
-    *true  = \&Data::MessagePack::true;
-    *false = \&Data::MessagePack::false;
+    *true    = \&Data::MessagePack::true;
+    *false   = \&Data::MessagePack::false;
+    *is_bool = \&Data::MessagePack::is_bool;
 }
 
 sub _unexpected {
@@ -223,7 +224,7 @@ sub _pack {
         }
     }
 
-    elsif ( ref( $value ) eq 'Data::MessagePack::Boolean' ) {
+    elsif ( is_bool( $value ) ) {
         return  CORE::pack( 'C', ${$value} ? 0xc3 : 0xc2 );
     }
 

--- a/t/60_compat_json.t
+++ b/t/60_compat_json.t
@@ -1,0 +1,42 @@
+#!perl -w
+use strict;
+use Test::Requires { 'JSON::PP' => 0 };
+use Test::More;
+use Data::MessagePack;
+
+# Test compatibility of JSON and MessagePack booleans
+
+my $JSON = 'JSON::PP';
+
+is( $JSON->true,  Data::MessagePack::true,  'true' );
+is( $JSON->false, Data::MessagePack::false, 'false' );
+
+my @TESTS = (
+    { json => '[true]' },
+    { json => '{"f":false}' },
+    { json => '{"x":{"a":null,"b":"xyz"},"y":[]}' },
+    { mp   => "\x81\xc4\x01\x32\xc0" },
+    { mp   => "\x92\x90\xc0" },
+    { mp   => "\x93\xc0\xc2\xc3" },
+);
+
+my $mp = Data::MessagePack->new->utf8;
+my $j  = $JSON->new->utf8;
+
+for my $t (@TESTS) {
+    my ( $fmt, $input ) = each %$t;
+    my ( $out1, $out2, $test );
+    if ( $fmt eq 'json' ) {
+        $out1 = $j->decode($input);
+        $out2 = $mp->unpack( $mp->pack($out1) );
+        $test = "From JSON through MP: $input";
+    }
+    elsif ( $fmt eq 'mp' ) {
+        $out1 = $mp->unpack($input);
+        $out2 = $j->decode( $j->encode($out1) );
+        $test = "From MP through JSON: " . $JSON->can('encode_json')->($out1);
+    }
+    is_deeply( $out1, $out2, $test );
+}
+
+done_testing;


### PR DESCRIPTION
This change promotes type compatibility with other
CPAN serialization modules like JSON.

This is another take at https://github.com/msgpack/msgpack-perl/issues/17 – see also https://github.com/msgpack/msgpack-perl/pull/34

BREAKING CHANGE: removes stringification of true()
to "true" and false() to "false". As the packages
Data::MessagePack::Boolean and Types::Serialiser::Boolean
are aliased, it is not safe to include this controverse
coertion (different modules may have different ideas
on what is a useful stringification of booleans).
The "bool" and "num" (0+) overloads should work as before.