### PR TITLE
Skip 05_preferred_int if use_quadmath is enabled

### DIFF
--- a/t/05_preferred_int.t
+++ b/t/05_preferred_int.t
@@ -2,6 +2,12 @@ use t::Util;
 use Test::More;
 use Data::MessagePack;
 use Data::Dumper;
+use Config;
+
+# if use_quadmath is enabled, integer literal precision is different from non use_quadmath perl
+use if defined $Config{usequadmath},
+    'Test::More', skip_all => 'quadmath is not support this test';
+
 no warnings; # shut up "Integer overflow in hexadecimal number"
 
 sub packit {


### PR DESCRIPTION
Overflowed integer literal value like 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
is different between use_quadmath enabled perl and use_quadmath disabled
perl(default).

CPAN tests are failed on some platforms which use use_quadmath Perl